### PR TITLE
Added bash to run run.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ENV CN="localhost"
 ENV DNAME="CN=$CN,O=Moodle,L=Perth,S=WA,C=AU"
 ENV CERT_SUBJ_ALT_NAMES="ip:127.0.0.1"
 
-CMD [ "run.sh" ]
+CMD [ "/bin/bash", "run.sh" ]


### PR DESCRIPTION
OS: Ubuntu 22.04, jammy
Docker: 24.0.4, build 3713ee1

Without the "bin/bash" in the CMD, after building an image from the docker file and then running it, Docker will raise an error:

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "run.sh": cannot run executable found relative to current directory: unknown.
```
This commit fixes it.